### PR TITLE
Handle case where plugin configuration does not exist

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -92,6 +92,10 @@ func projectParamFromFlags() (matcher.NamesPathsCfg, *config.PluginConfig, error
 
 	pluginConfig, err := config.PluginConfigFromFile(pluginConfigFileFlagVal)
 	if err != nil {
+		// if plugin config does not exist, continue with nil config
+		if errors.Is(err, os.ErrNotExist) {
+			return godelExcludeConfig, nil, nil
+		}
 		return godelExcludeConfig, nil, err
 	}
 	return godelExcludeConfig, pluginConfig, nil


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Make plugin run normally when configuration file does not exist.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

