### PR TITLE
Update logic for converting godel exclude names

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -78,6 +78,9 @@ func convertNamesPathConfigsToExclusionsPaths(namesPathsCfg matcher.NamesPathsCf
 		// name within a directory
 		out = append(out, fmt.Sprintf(`.+/%s$`, name))
 
+		// nested directory
+		out = append(out, fmt.Sprintf(`.+/%s/.+`, name))
+
 		// top-level name
 		out = append(out, fmt.Sprintf(`^%s$`, name))
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -372,6 +372,7 @@ linters:
   exclusions:
     paths:
       - ".+/.*\\.conjure.go$"
+      - ".+/.*\\.conjure.go/.+"
       - "^.*\\.conjure.go$"
       - internal/generated/.*
       - ^internal/generated$
@@ -493,6 +494,7 @@ linters:
   exclusions:
     paths:
       - ".+/.*\\.conjure.go$"
+      - ".+/.*\\.conjure.go/.+"
       - "^.*\\.conjure.go$"
       - internal/generated/.*
       - ^internal/generated$


### PR DESCRIPTION


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Makes it so that godel excludes specified in the "names" block are propertly translated to exclude subdirectories with that name.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

