### PR TITLE
Update logic for converting godel exclude names to match top-level directories

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -73,7 +73,7 @@ func convertNamesPathConfigsToExclusionsPaths(namesPathsCfg matcher.NamesPathsCf
 		return nil
 	}
 
-	out := make([]string, 0, len(namesPathsCfg.Names)*3+len(namesPathsCfg.Paths)*2)
+	out := make([]string, 0, len(namesPathsCfg.Names)*4+len(namesPathsCfg.Paths)*2)
 	for _, name := range namesPathsCfg.Names {
 		// name within a directory
 		out = append(out, fmt.Sprintf(`.+/%s$`, name))
@@ -83,6 +83,9 @@ func convertNamesPathConfigsToExclusionsPaths(namesPathsCfg matcher.NamesPathsCf
 
 		// top-level name
 		out = append(out, fmt.Sprintf(`^%s$`, name))
+
+		// top-level directory
+		out = append(out, fmt.Sprintf(`^%s/.+`, name))
 	}
 
 	for _, path := range namesPathsCfg.Paths {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -374,6 +374,7 @@ linters:
       - ".+/.*\\.conjure.go$"
       - ".+/.*\\.conjure.go/.+"
       - "^.*\\.conjure.go$"
+      - "^.*\\.conjure.go/.+"
       - internal/generated/.*
       - ^internal/generated$
 
@@ -496,6 +497,7 @@ linters:
       - ".+/.*\\.conjure.go$"
       - ".+/.*\\.conjure.go/.+"
       - "^.*\\.conjure.go$"
+      - "^.*\\.conjure.go/.+"
       - internal/generated/.*
       - ^internal/generated$
 


### PR DESCRIPTION

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixes issue where if a "name" exclude in `godel.yml` matched a top-level directory, the translated `golangci-lint` exclude rule did not properly exclude issues in that directory.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

