### PR TITLE
Add go-version-config to control go.mod version upgrades

### DIFF
--- a/.palantir/go-version-config.v2.yml
+++ b/.palantir/go-version-config.v2.yml
@@ -1,0 +1,5 @@
+version-selector: latest-first-release
+reason: |
+  godel repositories should always attempt to use the latest available major/minor version of Go so that their version
+  can be incremented before other repositories. This allows other repositories to use the version of godel and its
+  plugins/assets built with the new version of Go before they update their own version.


### PR DESCRIPTION
## Before this PR
The `go/manage-go-version-oss` excavator check would not update the go directive in the `go.mod` file until the centrally managed default is updated. Since this is a default plugin we need this to be updated more aggressively.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add go-version-config to control go.mod version upgrades
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

