### PR TITLE
Add "disable" option to configuration

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -24,8 +25,13 @@ var (
 	configCmd = &cobra.Command{
 		Use:   "config",
 		Short: "Prints the configuration used by the golangci-lint plugin",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			assetRunner, _, err := NewAssetRunner()
+			if err != nil {
+				return errors.Wrap(err, "failed to initialize golangci-lint asset runner")
+			}
 			_, _ = fmt.Fprint(cmd.OutOrStdout(), string(assetRunner.Config()))
+			return nil
 		},
 	}
 )

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -32,6 +32,16 @@ var (
 		Use:   "lint [flags] [checks]",
 		Short: "Run linters (runs all linters if none are specified)",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			assetRunner, pluginConfig, err := NewAssetRunner()
+			if err != nil {
+				return errors.Wrap(err, "failed to initialize golangci-lint asset runner")
+			}
+
+			// if plugin is disabled, do nothing
+			if pluginConfig != nil && pluginConfig.Disable {
+				return nil
+			}
+
 			preConfigArgs := []string{
 				"run",
 			}
@@ -51,7 +61,7 @@ var (
 				postConfigArgs = append(postConfigArgs, "--fix")
 			}
 
-			return runDelegatedGolangCILintCommand(preConfigArgs, postConfigArgs, cmd.OutOrStdout(), cmd.ErrOrStderr(), debugFlagVal)
+			return runDelegatedGolangCILintCommand(assetRunner, preConfigArgs, postConfigArgs, cmd.OutOrStdout(), cmd.ErrOrStderr(), debugFlagVal)
 		},
 	}
 )
@@ -63,7 +73,7 @@ var (
 // the same exit code as the asset runner process. As such, this function should be considered terminal: there should be
 // no expectation that this function returns control to the caller (including for running deferred functions or
 // cleanup).
-func runDelegatedGolangCILintCommand(preConfigArgs, postConfigArgs []string, stdout, stderr io.Writer, debugMode bool) error {
+func runDelegatedGolangCILintCommand(assetRunner *GolangCILintAssetRunner, preConfigArgs, postConfigArgs []string, stdout, stderr io.Writer, debugMode bool) error {
 	exitCode, err := assetRunner.RunGolangCILintWithConfig(preConfigArgs, postConfigArgs, stderr, stdout, debugMode)
 	if err != nil {
 		return err
@@ -76,29 +86,20 @@ func runDelegatedGolangCILintCommand(preConfigArgs, postConfigArgs []string, std
 	return nil
 }
 
-func getConfig(baseConfig []byte) (config.GolangCILintConfig, error) {
-	excludes, pluginConfig, err := projectParamFromFlags()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read project excludes from flags")
-	}
-	return config.DefaultPalantirConfigMergedWithExcludeMatchersAndPluginConfig(baseConfig, excludes, pluginConfig)
+func godelExcludeConfigFromFlags() (matcher.NamesPathsCfg, error) {
+	return godelconfig.ReadGodelConfigExcludesFromFile(godelConfigFileFlagVal)
 }
 
-func projectParamFromFlags() (matcher.NamesPathsCfg, *config.PluginConfig, error) {
-	godelExcludeConfig, err := godelconfig.ReadGodelConfigExcludesFromFile(godelConfigFileFlagVal)
-	if err != nil {
-		return godelExcludeConfig, nil, err
-	}
-
+func pluginConfigFromFlags() (*config.PluginConfig, error) {
 	pluginConfig, err := config.PluginConfigFromFile(pluginConfigFileFlagVal)
 	if err != nil {
 		// if plugin config does not exist, continue with nil config
 		if errors.Is(err, os.ErrNotExist) {
-			return godelExcludeConfig, nil, nil
+			return nil, nil
 		}
-		return godelExcludeConfig, nil, err
+		return nil, err
 	}
-	return godelExcludeConfig, pluginConfig, nil
+	return pluginConfig, nil
 }
 
 func init() {

--- a/cmd/linters.go
+++ b/cmd/linters.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +24,11 @@ var (
 		Use:   "linters [flags]",
 		Short: "List current linters configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDelegatedGolangCILintCommand([]string{"linters"}, nil, cmd.OutOrStdout(), cmd.ErrOrStderr(), debugFlagVal)
+			assetRunner, _, err := NewAssetRunner()
+			if err != nil {
+				return errors.Wrap(err, "failed to initialize golangci-lint asset runner")
+			}
+			return runDelegatedGolangCILintCommand(assetRunner, []string{"linters"}, nil, cmd.OutOrStdout(), cmd.ErrOrStderr(), debugFlagVal)
 		},
 	}
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,11 +16,11 @@ package cmd
 
 import (
 	"github.com/palantir/godel-golangci-lint-plugin/cmd/internal/assetloader"
+	"github.com/palantir/godel-golangci-lint-plugin/config"
 	"github.com/palantir/godel/v2/framework/pluginapi"
 	"github.com/palantir/pkg/cobracli"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var (
@@ -29,11 +29,6 @@ var (
 	pluginConfigFileFlagVal string
 	godelConfigFileFlagVal  string
 	assetsFlagVal           []string
-
-	// Package-level variable that is set by InitAssetCmds.
-	// Is guaranteed to be set and valid after InitAssetCmds is called (if it is not valid, an error is returned and
-	// the program will not run).
-	assetRunner *GolangCILintAssetRunner
 )
 
 var rootCmd = &cobra.Command{
@@ -44,23 +39,30 @@ func Execute() int {
 	return cobracli.ExecuteWithDebugVarAndDefaultParams(rootCmd, &debugFlagVal)
 }
 
-func InitAssetCmds(args []string) error {
-	if _, _, err := rootCmd.Traverse(args); err != nil && err != pflag.ErrHelp {
-		return errors.Wrapf(err, "failed to parse arguments")
-	}
-
+// NewAssetRunner initializes and returns a GolangCILintAssetRunner. The assets and the exclude and plugin configuration
+// are loaded based on flag values, Returns the loaded plugin configuration as well (which may be nil if it is empty).
+func NewAssetRunner() (*GolangCILintAssetRunner, *config.PluginConfig, error) {
 	assetInfo, err := assetloader.GetAssetInfo(assetsFlagVal)
 	if err != nil {
-		return err
+		return nil, nil, errors.Wrap(err, "failed to load assets")
 	}
 
-	golangCILintConfig, err := getConfig(assetInfo.ConfigProvidedByAsset)
+	excludes, err := godelExcludeConfigFromFlags()
 	if err != nil {
-		return err
+		return nil, nil, errors.Wrap(err, "failed to load project excludes from godel config")
 	}
 
-	assetRunner = NewGolangCILintAssetRunner(assetInfo.GolangCILintAssetPath, golangCILintConfig)
-	return nil
+	pluginConfig, err := pluginConfigFromFlags()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to load plugin configuration")
+	}
+
+	golangCILintConfig, err := config.DefaultPalantirConfigMergedWithExcludeMatchersAndPluginConfig(assetInfo.ConfigProvidedByAsset, excludes, pluginConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return NewGolangCILintAssetRunner(assetInfo.GolangCILintAssetPath, golangCILintConfig), pluginConfig, nil
 }
 
 func init() {

--- a/config/pluginconfig.go
+++ b/config/pluginconfig.go
@@ -27,6 +27,11 @@ import (
 // the configuration that can be specified by the user. This user-provided configuration
 // is merged with a hard-coded base configuration.
 type PluginConfig struct {
+	// Disable specifies whether the golangci-lint plugin should be disabled. If true, the "lint" command will be a
+	// noop. Exists to allow the entire plugin to be "turned off" without removing it from the godel configuration.
+	// This is a plugin-specific configuration value and is not merged into the golangci-lint configuration.
+	Disable bool `yaml:"disable,omitempty"`
+
 	Linters LintersConfig `yaml:"linters,omitempty"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/palantir/pkg/yamlpatch v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.10.1
-	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -180,6 +179,7 @@ require (
 	github.com/sourcegraph/go-diff v0.7.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.21.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.2.0 // indirect

--- a/main.go
+++ b/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/palantir/godel-golangci-lint-plugin/cmd"
@@ -25,12 +24,6 @@ import (
 func main() {
 	if ok := pluginapi.InfoCmd(os.Args, os.Stdout, cmd.PluginInfo); ok {
 		return
-	}
-
-	// initialize commands that require assets
-	if err := cmd.InitAssetCmds(os.Args[1:]); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Error: golangci-lint-plugin: failed to load asset: %v\n", err)
-		os.Exit(1)
 	}
 	os.Exit(cmd.Execute())
 }


### PR DESCRIPTION


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds the "disable" field to plugin configuration. When set to "true", disables the linter from running entirely.
==COMMIT_MSG==

Also refactors configuration loading logic so that the error that is printed when configuration is invalid is clearer (properly states that the issue is with configuration rather than the asset).

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
