### PR TITLE
Add "compiles" check to the "lint" task

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -17,16 +17,21 @@ package cmd
 import (
 	"io"
 	"os"
+	"slices"
 
 	"github.com/palantir/godel-golangci-lint-plugin/config"
+	"github.com/palantir/godel-golangci-lint-plugin/internal/compiles"
 	godelconfig "github.com/palantir/godel/v2/framework/godel/config"
 	"github.com/palantir/pkg/matcher"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
+const compilesCheckName = "compiles"
+
 var (
-	fixFlagVal bool
+	disableCompilesCheckFlagVal bool
+	fixFlagVal                  bool
 
 	lintCmd = &cobra.Command{
 		Use:   "lint [flags] [checks]",
@@ -40,6 +45,36 @@ var (
 			// if plugin is disabled, do nothing
 			if pluginConfig != nil && pluginConfig.Disable {
 				return nil
+			}
+
+			// if no checks were specified or "compiles" was specified, run compiles check first.
+			// If check fails, exit with the exit code.
+			// If check succeeds and "compiles" was specified as an argument, remove it from the arguments (it is not
+			// an actual check).
+			if compilesCheckArgIdx := slices.Index(args, compilesCheckName); len(args) == 0 || compilesCheckArgIdx != -1 {
+				// only run compiles check if it is not disabled by flag.
+				// not a conditional on the full block because the logic to remove "compiles" from args should still run.
+				if !disableCompilesCheckFlagVal {
+					// this should match the value that is used by golangci-lint. The current construction of the plugin
+					// invokes golangci-lint without any arguments, which causes it to use "./...".
+					const pkgSelector = "./..."
+					if compilesRunResult := compiles.Run([]string{pkgSelector}, debugFlagVal, cmd.OutOrStdout()); compilesRunResult != 0 {
+						os.Exit(compilesRunResult)
+					}
+				}
+
+				if compilesCheckArgIdx != -1 {
+					// remove "compiles" argument if it was provided
+					args = slices.Delete(args, compilesCheckArgIdx, compilesCheckArgIdx+1)
+
+					// if "compiles" was the only argument, exit successfully
+					if len(args) == 0 {
+						// Print success output. Only do this if exiting at this point because otherwise golangci-lint
+						// will print its own output.
+						compiles.SuccessOutput(cmd.OutOrStdout())
+						return nil
+					}
+				}
 			}
 
 			preConfigArgs := []string{
@@ -103,6 +138,7 @@ func pluginConfigFromFlags() (*config.PluginConfig, error) {
 }
 
 func init() {
+	lintCmd.Flags().BoolVarP(&disableCompilesCheckFlagVal, "disable-compiles-check", "", false, "Disable the compiles check that the plugin runs before invoking linters")
 	lintCmd.Flags().BoolVarP(&fixFlagVal, "fix", "", false, "Fix found issues (if it's supported by the linter)")
 
 	rootCmd.AddCommand(lintCmd)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/tools v0.37.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -219,7 +220,6 @@ require (
 	golang.org/x/sys v0.37.0 // indirect
 	golang.org/x/term v0.35.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
-	golang.org/x/tools v0.37.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	honnef.co/go/tools v0.6.1 // indirect

--- a/internal/compiles/compiles.go
+++ b/internal/compiles/compiles.go
@@ -1,0 +1,138 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compiles
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// Run loads the packages matching the provided patterns and prints any loading errors to the provided writer. Returns
+// exit code 0 if there were no errors, or 1 if there were any errors.
+//
+// If any package-level errors are encountered, they are printed to the provided writer and a summary is printed at the
+// end. If no errors are encountered, nothing is printed to the provided writer (unless debugMode is true).
+//
+// If debugMode is true, prints debug information about loading time to the provided writer.
+//
+// When used before invoking golangci-lint, the packages.Config that is used to load packages by this function should
+// semantically match the packages.Config that will be used by golangci-lint. Currently, this invariant is known to be
+// true based on the design: godel-golangci-lint-plugin does not expose any way for end users to specify build tags or
+// exclude test packages, so the configuration passed to packages.Load by this function should match the configuration
+// used by golangci-lint. However, if aspects like these are made configurable in the future, this function needs to be
+// updated to ensure that it loads packages in the same manner (otherwise, the errors reported by this function may be
+// for packages/load modes that do not match those used by golangci-lint).
+func Run(pkgPatterns []string, debugMode bool, out io.Writer) int {
+	var startLoadingTime time.Time
+	if debugMode {
+		_, _ = fmt.Fprintln(out, "Loading packages for \"compiles\" check:", strings.Join(pkgPatterns, " "))
+		startLoadingTime = time.Now()
+	}
+	initialPkgs, err := load(pkgPatterns)
+	if err != nil {
+		_, _ = fmt.Fprintln(out, err)
+		return 1
+	}
+	if debugMode {
+		timeToLoadPackages := time.Since(startLoadingTime)
+		_, _ = fmt.Fprintln(out, "Finished loading packages for \"compiles\" check: took", timeToLoadPackages.String())
+	}
+
+	if numIssues := printErrors(initialPkgs, out, modulePathPkgErrorProcessor); numIssues > 0 {
+		_, _ = fmt.Fprintf(out, "%d issues:\n", numIssues)
+		_, _ = fmt.Fprintf(out, "* compiles: %d\n", numIssues)
+		return 1
+	}
+
+	return 0
+}
+
+func SuccessOutput(out io.Writer) {
+	// match output of golangci-lint when no issues are found
+	_, _ = fmt.Fprintln(out, "0 issues.")
+}
+
+// load loads the specified packages. Returns only top-level loading errors. Does not consider errors in packages.
+// Loads packages using the mode (packages.LoadAllSyntax | packages.NeedModule) and with tests included. Does not
+// configure any custom build flags or environment variables.
+func load(patterns []string) ([]*packages.Package, error) {
+	conf := packages.Config{
+		Mode:  packages.LoadAllSyntax | packages.NeedModule,
+		Tests: true,
+	}
+	initial, err := packages.Load(&conf, patterns...)
+	if err == nil && len(initial) == 0 {
+		err = fmt.Errorf("%s matched no packages", strings.Join(patterns, " "))
+	}
+	return initial, err
+}
+
+type pkgErrorProcessor func(pkg *packages.Package, err packages.Error) packages.Error
+
+// modulePathPkgErrorProcessor is a pkgErrorProcessor that trims the module path prefix from the position of each error.
+func modulePathPkgErrorProcessor(pkg *packages.Package, err packages.Error) packages.Error {
+	if pkg.Module == nil {
+		return err
+	}
+	prefixToTrim := pkg.Module.Dir
+	const pathSeparator = string(filepath.Separator)
+	if prefixToTrim != "" && !strings.HasSuffix(prefixToTrim, pathSeparator) {
+		prefixToTrim += pathSeparator
+	}
+	err.Pos = strings.TrimPrefix(err.Pos, prefixToTrim)
+	return err
+}
+
+// printErrors prints all errors in the provided packages to the provided writer, one per line. If there is a module
+// error in the package, prints it once per package. Packages are visited according to the order returned by
+// packages.Postorder. If processPkgError is not nil, it is called for each package error and its result is printed.
+//
+// Based on the https://pkg.go.dev/golang.org/x/tools/go/packages#PrintErrors function -- the primary differences are
+// that output is printed to the supplied io.Writer (rather than hard-coding os.Stderr), and that package errors can be
+// processed by the provided function before being printed.
+func printErrors(pkgs []*packages.Package, out io.Writer, processPkgError pkgErrorProcessor) int {
+	var n int
+	errModules := make(map[*packages.Module]bool)
+	seenErrs := make(map[packages.Error]bool)
+	for pkg := range packages.Postorder(pkgs) {
+		// print all package errors
+		for _, err := range pkg.Errors {
+			if processPkgError != nil {
+				err = processPkgError(pkg, err)
+			}
+			// skip duplicate errors (common case is regular package and test package both reporting the same error)
+			if seenErrs[err] {
+				continue
+			}
+			_, _ = fmt.Fprintln(out, err.Error())
+			n++
+			seenErrs[err] = true
+		}
+
+		// print pkg.Module.Error once if present
+		mod := pkg.Module
+		if mod != nil && mod.Error != nil && !errModules[mod] {
+			errModules[mod] = true
+			_, _ = fmt.Fprintln(out, mod.Error.Err)
+			n++
+		}
+	}
+	return n
+}


### PR DESCRIPTION


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Updates the golangci-lint plugin so that the "lint" task runs a "compiles" check before running linters.

Specifically, when the "lint" task is run, the plugin loads all packages ("./..."), prints all errors that are encountered, and if there are any errors prints a summary and exits.

This ensures that the "lint" task will print all compile errors for packages before running linters using golangci-lint (which has the behavior of only printing the first package error encountered and then exiting).

"compiles" is treated as if it were a linter (it is supported as an argument to "lint"), but functionally it is only run by the plugin and is never actually passed to (or configured by) golangci-lint.

Also adds the "--disable-compiles-check" flag to the "lint" command which, when specified or set to "true", disables this behavior.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

