### PR TITLE
Update compiles check to be more efficient

### DIFF
--- a/internal/compiles/compiles.go
+++ b/internal/compiles/compiles.go
@@ -74,7 +74,7 @@ func SuccessOutput(out io.Writer) {
 // configure any custom build flags or environment variables.
 func load(patterns []string) ([]*packages.Package, error) {
 	conf := packages.Config{
-		Mode:  packages.LoadAllSyntax | packages.NeedModule,
+		Mode:  packages.LoadTypes | packages.NeedModule,
 		Tests: true,
 	}
 	initial, err := packages.Load(&conf, patterns...)


### PR DESCRIPTION


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update package loading to only load the information required to detect compilation errors. This should significantly reduce the amount of memory used by the operation, which should help with OOM issues in CI.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

